### PR TITLE
DRAFT: [fix] plagiarism check to be case insensitive

### DIFF
--- a/krummstab/commands/collect.py
+++ b/krummstab/commands/collect.py
@@ -55,7 +55,8 @@ def validate_marks_json(
     invalid_marks = [
         mark
         for mark in marks_list
-        if not utils.is_float(mark) and mark.lower() != strings.PLAGIARISM
+        if not utils.represents_float(mark)
+        and mark.lower() != strings.PLAGIARISM
     ]
     if invalid_marks:
         logging.critical(
@@ -67,7 +68,7 @@ def validate_marks_json(
     if not all(
         (float(mark) / _the_config.min_point_unit).is_integer()
         for mark in marks_list
-        if utils.is_float(mark)
+        if utils.represents_float(mark)
     ):
         logging.critical(
             f"'{marks_json_file.name}' contains marks that are more "
@@ -224,7 +225,8 @@ def create_individual_marks_file(
         team_key = submission.team.get_team_key()
         for student in submission.team.members:
             student_key = student.email.lower()
-            student_marks.update({student_key: team_marks.get(team_key)})
+            mark = utils.make_lower_case_if_possible(team_marks.get(team_key))
+            student_marks.update({student_key: mark})
     file_content = {
         "tutor_name": _the_config.tutor_name,
         "adam_sheet_name": sheet.name,

--- a/krummstab/commands/collect.py
+++ b/krummstab/commands/collect.py
@@ -54,7 +54,7 @@ def validate_marks_json(
     if not all(
         (float(mark) / _the_config.min_point_unit).is_integer()
         for mark in marks_list
-        if mark != strings.PLAGIARISM
+        if mark.capitalize() != strings.PLAGIARISM
     ):
         logging.critical(
             f"'{marks_json_file.name}' contains marks that are more"

--- a/krummstab/commands/collect.py
+++ b/krummstab/commands/collect.py
@@ -51,15 +51,28 @@ def validate_marks_json(
         logging.critical(
             f"There are missing points in the '{marks_json_file.name}' file!"
         )
+
+    invalid_marks = [
+        mark
+        for mark in marks_list
+        if not utils.is_float(mark) and mark.lower() != strings.PLAGIARISM
+    ]
+    if invalid_marks:
+        logging.critical(
+            f"'{marks_json_file.name}' contains the following marks that are "
+            f"neither a number nor the magic string '{strings.PLAGIARISM}':\n"
+            f"    {invalid_marks}."
+        )
+
     if not all(
         (float(mark) / _the_config.min_point_unit).is_integer()
         for mark in marks_list
-        if mark.capitalize() != strings.PLAGIARISM
+        if utils.is_float(mark)
     ):
         logging.critical(
-            f"'{marks_json_file.name}' contains marks that are more"
-            " fine-grained than allowed! You may only award points in"
-            f" '{_the_config.min_point_unit}' increments."
+            f"'{marks_json_file.name}' contains marks that are more "
+            "fine-grained than allowed! You may only award points in "
+            f"{_the_config.min_point_unit} increments."
         )
 
 

--- a/krummstab/commands/summarize.py
+++ b/krummstab/commands/summarize.py
@@ -23,6 +23,13 @@ def convert_to_float_if_possible(value):
         return value
 
 
+def make_lower_case_if_possible(value):
+    try:
+        return value.lower()
+    except AttributeError:
+        return value
+
+
 def total_score(values):
     total = 0
     for v in values:
@@ -793,7 +800,9 @@ def load_marks_files(marks_dir: Path, _the_config: config.Config):
                             f"{exercise} of sheet {sheet_name} is marked "
                             f"multiple times for {email}!"
                         )
-                    students_marks[email][sheet_name][exercise] = mark
+                    students_marks[email][sheet_name][exercise] = (
+                        make_lower_case_if_possible(mark)
+                    )
                     if exercise not in graded_sheet_names[sheet_name]:
                         graded_sheet_names[sheet_name].append(exercise)
         else:
@@ -804,7 +813,9 @@ def load_marks_files(marks_dir: Path, _the_config: config.Config):
                         f"Sheet {sheet_name} is marked multiple times for "
                         f"{email}!"
                     )
-                students_marks[email][sheet_name] = mark
+                students_marks[email][sheet_name] = make_lower_case_if_possible(
+                    mark
+                )
     for sheet_name, tutor_list in tutors.items():
         if sheet_name not in _the_config.max_points_per_sheet.keys():
             logging.warning(

--- a/krummstab/commands/summarize.py
+++ b/krummstab/commands/summarize.py
@@ -16,20 +16,6 @@ from .. import config, strings, utils
 from ..teams import create_email_to_name_dict
 
 
-def convert_to_float_if_possible(value):
-    try:
-        return float(value)
-    except ValueError:
-        return value
-
-
-def make_lower_case_if_possible(value):
-    try:
-        return value.lower()
-    except AttributeError:
-        return value
-
-
 def total_score(values):
     total = 0
     for v in values:
@@ -420,7 +406,7 @@ class PointsSummarySheetBuilder:
                 self.write_formula(row, c, formula)
             else:
                 marks = student_marks.get(sheet, "")
-                self.write(row, c, convert_to_float_if_possible(marks))
+                self.write(row, c, utils.convert_to_float_if_possible(marks))
         return OpenpyxlRangeRef(row, col, row, col + len(self.sheets) - 1)
 
     def write_student_total_marks(self, row, col, ref_individual_marks):
@@ -719,7 +705,7 @@ class PointsSummarySheetBuilder:
                     self.write(
                         r,
                         task_column[sheet, task],
-                        convert_to_float_if_possible(task_marks),
+                        utils.convert_to_float_if_possible(task_marks),
                     )
 
                 col_sheet = sheet_column[sheet]
@@ -801,7 +787,7 @@ def load_marks_files(marks_dir: Path, _the_config: config.Config):
                             f"multiple times for {email}!"
                         )
                     students_marks[email][sheet_name][exercise] = (
-                        make_lower_case_if_possible(mark)
+                        utils.make_lower_case_if_possible(mark)
                     )
                     if exercise not in graded_sheet_names[sheet_name]:
                         graded_sheet_names[sheet_name].append(exercise)
@@ -813,8 +799,8 @@ def load_marks_files(marks_dir: Path, _the_config: config.Config):
                         f"Sheet {sheet_name} is marked multiple times for "
                         f"{email}!"
                     )
-                students_marks[email][sheet_name] = make_lower_case_if_possible(
-                    mark
+                students_marks[email][sheet_name] = (
+                    utils.make_lower_case_if_possible(mark)
                 )
     for sheet_name, tutor_list in tutors.items():
         if sheet_name not in _the_config.max_points_per_sheet.keys():

--- a/krummstab/strings.py
+++ b/krummstab/strings.py
@@ -1,4 +1,4 @@
-PLAGIARISM = "Plagiarism"
+PLAGIARISM = "plagiarism"
 
 # File name components
 FEEDBACK_FILE_PREFIX = "feedback_"

--- a/krummstab/utils.py
+++ b/krummstab/utils.py
@@ -8,6 +8,7 @@ import tempfile
 import jsonschema
 
 from collections import defaultdict
+from typing import Any
 from zipfile import ZipFile
 
 from .students import Student
@@ -180,7 +181,7 @@ def read_json(source: str | pathlib.Path, source_name: str = "file") -> dict:
     return data
 
 
-# File Handling ----------------------------------------------------------------
+# File handling ----------------------------------------------------------------
 
 
 def is_hidden_file(name: str) -> bool:
@@ -243,12 +244,25 @@ def unzip_or_move_adam_zip(
         shutil.copytree(unzipped_path, unzipped_destination_path)
 
 
-# Misc -------------------------------------------------------------------------
+# Type juggling ----------------------------------------------------------------
 
 
-def is_float(s: str) -> bool:
+def represents_float(value: Any) -> bool:
     try:
-        float(s)
+        float(value)
     except ValueError:
         return False
     return True
+
+
+def convert_to_float_if_possible(value: Any) -> Any:
+    if represents_float(value):
+        return float(value)
+    return value
+
+
+def make_lower_case_if_possible(value: Any) -> Any:
+    try:
+        return value.lower()
+    except AttributeError:
+        return value

--- a/krummstab/utils.py
+++ b/krummstab/utils.py
@@ -241,3 +241,14 @@ def unzip_or_move_adam_zip(
             pathlib.Path(destination) / unzipped_path.name
         )
         shutil.copytree(unzipped_path, unzipped_destination_path)
+
+
+# Misc -------------------------------------------------------------------------
+
+
+def is_float(s: str) -> bool:
+    try:
+        float(s)
+    except ValueError:
+        return False
+    return True


### PR DESCRIPTION
Currently, if you write "plagiarism" in your points file, Krummstab crashes with an unhelpful message. It took me quiet a while to find out this was the case. This sould make the casing correct no matter how you write it in your config. 

I did not test this locally, but I think it is straight forward.

- [ ] Test this locally 